### PR TITLE
Bump `ringbuf` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ rustc_version = "^0.4"
 futures = "^0.3"
 log = "^0.4"
 log-derive = "^0.4"
-ringbuf = "^0.2"
+ringbuf = "^0.3"
 
 [dependencies.rand]
 optional = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ mod import
 	pub(crate) use
 	{
 		std         :: { fmt, task::Waker                                 } ,
-		ringbuf     :: { RingBuffer as SyncRingBuffer, Producer, Consumer } ,
+		ringbuf     :: { HeapRb as SyncRingBuffer, Producer, Consumer     } ,
 		futures     :: { AsyncRead, AsyncWrite, AsyncReadExt              } ,
 		futures::io :: { ReadHalf, WriteHalf                              } ,
 		futures     :: { task::noop_waker                                 } ,

--- a/src/ring_buffer.rs
+++ b/src/ring_buffer.rs
@@ -1,5 +1,7 @@
 use crate::import::*;
 
+type Producer<T> = ringbuf::HeapProducer<T>;
+type Consumer<T> = ringbuf::HeapConsumer<T>;
 
 /// A RingBuffer that implements `AsyncRead` and `AsyncWrite` from the futures library.
 ///
@@ -79,7 +81,7 @@ impl<T: Sized + Copy> RingBuffer<T>
 	//
 	pub fn remaining(&self) -> usize
 	{
-		self.producer.remaining()
+		self.producer.free_len()
 	}
 }
 


### PR DESCRIPTION
<!--- When contributing all contributions should branch off the -->
<!--- dev branch as master is only used for releases. -->

<!--- Check CONTRIBUTING.md for more information-->

<!--- Please describe the changes and motivation for the PR below -->

This PR bumps the version of the `ringbuf` crate. I tried to make the changes as non-invasive as possible :)

I believe due to the `From<(Producer,Consumer)>` impl, this is a breaking change. Should I bump the version in the manifest or are you going to do that at a later point?